### PR TITLE
ci(workflows): upgrade actions/checkout and actions/setup-python to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,8 @@ jobs:
   commitlint:
     name: Conventional Commits
     runs-on: ubuntu-latest
-    # Opt into Node.js 24 (Node.js 20 is deprecated)
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    # Run on every push and PR; skip if there are no new commits
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -33,12 +29,10 @@ jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -56,15 +50,13 @@ jobs:
   test:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -87,12 +79,10 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [lint]
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,15 +15,12 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    # Opt into Node.js 24 (Node.js 20 is deprecated)
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,8 @@ jobs:
     name: Publish Release from Tag
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    # Opt into Node.js 24 (Node.js 20 is deprecated)
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,14 +52,12 @@ jobs:
     name: Manual Release (${{ inputs.release_type }})
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -102,15 +97,13 @@ jobs:
     name: Update Changelog
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
The v4/v5 versions of these actions are deprecated and running on Node.js 20 which will be removed from GitHub Actions runners on September 16th, 2026.

Upgraded:
- actions/checkout@v4 → actions/checkout@v6
- actions/setup-python@v5 → actions/setup-python@v6

Also removed the now-unnecessary FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variables since the updated actions natively support newer Node.js versions.