### PR TITLE
chore(release): bump version to v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.2.5] - 2026-04-24
 
 ### Bug Fixes


### PR DESCRIPTION
Release PR: actualiza pyproject.toml, _version.py y regenera CHANGELOG.md con git-cliff.