### PR TITLE
chore(release): bump version to v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-## [0.2.5] - 2026-04-24
+## [0.2.6] - 2026-04-25
 
 ### Bug Fixes
 
-- Fixes (#6) ([#6](https://github.com/EL-BID/Energizados/pull/6))
+- Fixes (#6)
+- **release:** Handle missing git-cliff gracefully (#13)
+- **workflow:** Use master instead of main as default branch (#14)
 
 ### CI/CD
 
-- Opt into Node.js 24 for GitHub Actions (#10) ([#10](https://github.com/EL-BID/Energizados/pull/10))
-- **workflows:** Upgrade actions/checkout and actions/setup-python to v6
-- **workflows:** Upgrade actions/checkout and actions/setup-python to v6 (#11) ([#11](https://github.com/EL-BID/Energizados/pull/11))
+- Opt into Node.js 24 for GitHub Actions (#10)
+- **workflows:** Upgrade actions/checkout and actions/setup-python to v6 (#11)
 
 ### Features
 
-- **refactor:** Major framework refactor — ETL, EDA, evaluation, security (#4) ([#4](https://github.com/EL-BID/Energizados/pull/4))
-- V0.2.3 — new transformers, GeoFeaturesETL improvements, ConsumptionPatterns extensions, and release automation (#9) ([#9](https://github.com/EL-BID/Energizados/pull/9))
+- **refactor:** Major framework refactor — ETL, EDA, evaluation, security (#4)
+- V0.2.3 — new transformers, GeoFeaturesETL improvements, ConsumptionPatterns extensions, and release automation (#9)
 
 ### Miscellaneous
 
 - Update license to new IDB template (keeps 2023) and add AI_BID disclaimer
-- Bump version to 0.2.2 (#8) ([#8](https://github.com/EL-BID/Energizados/pull/8))
+- Bump version to 0.2.2 (#8)
+- Add unreleased section to changelog (#15)
+- Add unreleased section to changelog (#16)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "energizados"
-version = "0.2.5"
+version = "0.2.6"
 description = "Framework para detección de fraude en consumo energético"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/energizados/_version.py
+++ b/src/energizados/_version.py
@@ -2,7 +2,7 @@
 
 import importlib.metadata
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 # Reserved key used inside each config section to track schema evolution.
 SCHEMA_VERSION_KEY = "schema_version"


### PR DESCRIPTION
Release v0.2.6: actualiza pyproject.toml, _version.py y regenera CHANGELOG.md con git-cliff.