### PR TITLE
feat(web): Phase 5 — SSE live progress for the web console (MVP complete)

### DIFF
--- a/src/energizados/web/app.py
+++ b/src/energizados/web/app.py
@@ -6,6 +6,7 @@ Implements Phase 1 endpoints (tasks 5.9-5.18) with HTMX support.
 Implements Phase 2 endpoints (runs list, detail, artifact serving) with security guards.
 """
 
+import asyncio
 import json
 import logging
 from collections import deque
@@ -16,7 +17,7 @@ from typing import Any, Dict, List, Optional
 import yaml
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -331,6 +332,98 @@ async def list_jobs(request: Request, status: str = None):
     return templates.TemplateResponse(
         request, "job_list.html", {"jobs": jobs, "status_filter": status_filter}
     )
+
+
+# SSE constants
+SSE_POLL_INTERVAL_SECONDS = 1.0
+SSE_MAX_POLL_ITERATIONS = 240  # Safety cap: 4 minutes at 1s interval
+
+
+@app.get("/jobs/{job_id}/progress")
+async def get_job_progress(job_id: str):
+    """
+    SSE endpoint for live job progress (Task 5).
+
+    Streams job events from SQLite in Server-Sent Events format.
+    Returns 404 if job not found (before streaming).
+
+    Args:
+        job_id: Job identifier
+
+    Returns:
+        StreamingResponse with text/event-stream content-type
+    """
+    # Get job first - raise 404 BEFORE entering generator
+    store = JobStore()
+    job = store.get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    async def event_stream():
+        """Async generator for SSE events."""
+        after_seq = 0
+        iteration = 0
+        initial_sent = False
+
+        try:
+            while iteration < SSE_MAX_POLL_ITERATIONS:
+                # Fetch new events
+                try:
+                    events = store.get_job_events_since(job_id, after_seq)
+                except Exception as e:
+                    logger.error(f"Error fetching events for job {job_id}: {e}")
+                    events = []
+
+                # Stream events
+                for event in events:
+                    yield f"data: {json.dumps(event)}\n\n"
+                    after_seq = max(after_seq, event["seq"])
+
+                # Check job status (re-fetch to get latest state)
+                current_job = store.get_job(job_id)
+
+                # Send initial heartbeat for running jobs with no events
+                if not initial_sent and not events and not current_job.is_terminal():
+                    yield f"event: connected\ndata: {json.dumps({'job_id': job_id, 'status': current_job.status.value})}\n\n"
+                    initial_sent = True
+
+                # Check if job is terminal
+                if current_job.is_terminal():
+                    # Emit terminal signal and close
+                    terminal_event = {
+                        "status": current_job.status.value,
+                        "finished_at": current_job.finished_at,
+                    }
+                    yield f"event: terminal\ndata: {json.dumps(terminal_event)}\n\n"
+                    logger.info(f"Job {job_id} terminal, closing SSE stream")
+                    return
+
+                # For testing: if we've sent events or heartbeat and job is still running, close quickly
+                if not current_job.is_terminal():
+                    # If we have sent any content (events or heartbeat), close after 1 iteration for test determinism
+                    if (initial_sent or events) and iteration >= 1:
+                        yield f"event: terminal\ndata: {json.dumps({'status': 'test_complete', 'reason': 'running_job_test_determinism'})}\n\n"
+                        return
+
+                # Wait before next poll
+                await asyncio.sleep(SSE_POLL_INTERVAL_SECONDS)
+                iteration += 1
+
+            # Safety cap reached - close gracefully
+            logger.warning(
+                f"Job {job_id} SSE stream reached safety cap ({SSE_MAX_POLL_ITERATIONS} iterations)"
+            )
+            yield f"event: terminal\ndata: {json.dumps({'status': 'timeout', 'reason': 'max_iterations'})}\n\n"
+
+        except GeneratorExit:
+            # Client disconnected
+            logger.info(f"Job {job_id} SSE client disconnected")
+        except Exception as e:
+            # Unexpected error - log and close
+            logger.error(f"Job {job_id} SSE stream error: {e}")
+            yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
 @app.get("/jobs/{job_id}")

--- a/src/energizados/web/app.py
+++ b/src/energizados/web/app.py
@@ -336,11 +336,17 @@ async def list_jobs(request: Request, status: str = None):
 
 # SSE constants
 SSE_POLL_INTERVAL_SECONDS = 1.0
-SSE_MAX_POLL_ITERATIONS = 240  # Safety cap: 4 minutes at 1s interval
+SSE_MAX_POLL_ITERATIONS = (
+    3600  # Safety cap: 1 hour at 1s interval (true backstop, not regular occurrence)
+)
+SSE_EVENT_CONNECTED = "connected"
+SSE_EVENT_TERMINAL = "terminal"
+SSE_EVENT_ERROR = "error"
+# Client JS in job_detail.html must mirror these event names
 
 
 @app.get("/jobs/{job_id}/progress")
-async def get_job_progress(job_id: str):
+async def get_job_progress(job_id: str, request: Request):
     """
     SSE endpoint for live job progress (Task 5).
 
@@ -349,6 +355,7 @@ async def get_job_progress(job_id: str):
 
     Args:
         job_id: Job identifier
+        request: FastAPI request (for Last-Event-ID header)
 
     Returns:
         StreamingResponse with text/event-stream content-type
@@ -359,9 +366,15 @@ async def get_job_progress(job_id: str):
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    async def event_stream():
+    # Read Last-Event-ID header for resume (default 0 if missing/invalid)
+    last_event_id = request.headers.get("last-event-id")
+    try:
+        start_after_seq = int(last_event_id) if last_event_id else 0
+    except ValueError:
+        start_after_seq = 0
+
+    async def event_stream(after_seq: int = 0):
         """Async generator for SSE events."""
-        after_seq = 0
         iteration = 0
         initial_sent = False
 
@@ -374,9 +387,9 @@ async def get_job_progress(job_id: str):
                     logger.error(f"Error fetching events for job {job_id}: {e}")
                     events = []
 
-                # Stream events
+                # Stream events with event-id for resume
                 for event in events:
-                    yield f"data: {json.dumps(event)}\n\n"
+                    yield f"id: {event['seq']}\ndata: {json.dumps(event)}\n\n"
                     after_seq = max(after_seq, event["seq"])
 
                 # Check job status (re-fetch to get latest state)
@@ -384,7 +397,7 @@ async def get_job_progress(job_id: str):
 
                 # Send initial heartbeat for running jobs with no events
                 if not initial_sent and not events and not current_job.is_terminal():
-                    yield f"event: connected\ndata: {json.dumps({'job_id': job_id, 'status': current_job.status.value})}\n\n"
+                    yield f"event: {SSE_EVENT_CONNECTED}\ndata: {json.dumps({'job_id': job_id, 'status': current_job.status.value})}\n\n"
                     initial_sent = True
 
                 # Check if job is terminal
@@ -394,7 +407,7 @@ async def get_job_progress(job_id: str):
                         "status": current_job.status.value,
                         "finished_at": current_job.finished_at,
                     }
-                    yield f"event: terminal\ndata: {json.dumps(terminal_event)}\n\n"
+                    yield f"event: {SSE_EVENT_TERMINAL}\ndata: {json.dumps(terminal_event)}\n\n"
                     logger.info(f"Job {job_id} terminal, closing SSE stream")
                     return
 
@@ -403,11 +416,11 @@ async def get_job_progress(job_id: str):
                 await asyncio.sleep(SSE_POLL_INTERVAL_SECONDS)
                 iteration += 1
 
-            # Safety cap reached - close gracefully
+            # Safety cap reached - close silently (client reconnects with Last-Event-ID)
             logger.warning(
                 f"Job {job_id} SSE stream reached safety cap ({SSE_MAX_POLL_ITERATIONS} iterations)"
             )
-            yield f"event: terminal\ndata: {json.dumps({'status': 'timeout', 'reason': 'max_iterations'})}\n\n"
+            return
 
         except GeneratorExit:
             # Client disconnected
@@ -415,9 +428,11 @@ async def get_job_progress(job_id: str):
         except Exception as e:
             # Unexpected error - log and close
             logger.error(f"Job {job_id} SSE stream error: {e}")
-            yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"
+            yield f"event: {SSE_EVENT_ERROR}\ndata: {json.dumps({'error': str(e)})}\n\n"
 
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
+    return StreamingResponse(
+        event_stream(after_seq=start_after_seq), media_type="text/event-stream"
+    )
 
 
 @app.get("/jobs/{job_id}")

--- a/src/energizados/web/app.py
+++ b/src/energizados/web/app.py
@@ -398,14 +398,8 @@ async def get_job_progress(job_id: str):
                     logger.info(f"Job {job_id} terminal, closing SSE stream")
                     return
 
-                # For testing: if we've sent events or heartbeat and job is still running, close quickly
-                if not current_job.is_terminal():
-                    # If we have sent any content (events or heartbeat), close after 1 iteration for test determinism
-                    if (initial_sent or events) and iteration >= 1:
-                        yield f"event: terminal\ndata: {json.dumps({'status': 'test_complete', 'reason': 'running_job_test_determinism'})}\n\n"
-                        return
-
-                # Wait before next poll
+                # Job still running: wait before next poll. The loop only exits when
+                # the job transitions to a terminal state or the safety cap is reached.
                 await asyncio.sleep(SSE_POLL_INTERVAL_SECONDS)
                 iteration += 1
 

--- a/src/energizados/web/runner.py
+++ b/src/energizados/web/runner.py
@@ -48,8 +48,26 @@ def _run_job(job_id: str, config: Dict[str, Any]):
             logger.error(f"[{job_id}] Error in step {step_name}: {exception}")
 
         def progress_callback(event):
-            # Stub for Phase 1 - will write to job_events table in Phase 5
-            pass
+            """
+            Write progress events to job_events table (Phase 5).
+
+            Captures job_id from closure. Runs in child process.
+            Must NOT raise — errors logged and swallowed.
+            """
+            try:
+                # Import JobStore here (runs in child process)
+                from energizados.web.store import JobStore
+
+                # Create JobStore with same db_path as parent process
+                # (Worker ensures db_path consistency across processes)
+                store = JobStore()
+                # Map ProgressEvent → job_event row
+                # Note: event.run_id may be "unknown" early; job_id is the key
+                store.append_job_event(job_id, event)
+            except Exception as e:
+                # Callback failure must not crash pipeline
+                logger_callback = logging.getLogger(__name__)
+                logger_callback.error(f"Progress callback failed for job {job_id}: {e}")
 
         # Build and run pipeline
         builder = ConfigPipelineBuilder(config=config)

--- a/src/energizados/web/store.py
+++ b/src/energizados/web/store.py
@@ -71,7 +71,24 @@ class JobStore:
                 )
                 """)
 
-            # Create job_events table (reserved for Phase 5 SSE; NOT populated in Phase 1)
+            # Migrate job_events: drop if percent is INTEGER (old schema from Phase 1)
+            # Check if job_events table exists and has INTEGER percent column
+            existing_tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='job_events'"
+            ).fetchall()
+
+            if existing_tables:
+                existing_columns = conn.execute("PRAGMA table_info(job_events)").fetchall()
+                percent_col = [c for c in existing_columns if c[1] == "percent"]
+
+                # If percent column exists and is INTEGER, drop table for migration
+                if percent_col and len(percent_col) > 0 and percent_col[0][2] == "INTEGER":
+                    logger.info(
+                        "Migrating job_events.percent: INTEGER → REAL (dropping empty table)"
+                    )
+                    conn.execute("DROP TABLE job_events")
+
+            # Create job_events table with corrected schema (percent as REAL nullable)
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS job_events (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -80,7 +97,7 @@ class JobStore:
                     phase TEXT NOT NULL,
                     step_name TEXT NOT NULL,
                     message TEXT NOT NULL,
-                    percent INTEGER,
+                    percent REAL,
                     timestamp TEXT NOT NULL,
                     FOREIGN KEY (job_id) REFERENCES jobs(job_id)
                 )
@@ -386,3 +403,73 @@ class JobStore:
             return None
 
         return JobRow.from_row(row)
+
+    def append_job_event(self, job_id: str, event) -> bool:
+        """
+        Append a progress event to job_events table.
+
+        Args:
+            job_id: Job identifier
+            event: ProgressEvent from pipeline execution
+
+        Returns:
+            True if written, False on error (logged, never raises)
+
+        Note:
+            Must NOT raise — called from worker child process callback.
+            Errors are logged and swallowed to avoid crashing the job.
+        """
+        try:
+            with self._get_connection() as conn:
+                # Get next seq for this job (transaction ensures monotonic)
+                cursor = conn.execute(
+                    "SELECT COALESCE(MAX(seq), 0) FROM job_events WHERE job_id = ?", (job_id,)
+                )
+                next_seq = cursor.fetchone()[0] + 1
+
+                # Insert event
+                conn.execute(
+                    """
+                    INSERT INTO job_events (job_id, seq, phase, step_name, message, percent, timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                    (
+                        job_id,
+                        next_seq,
+                        event.phase,
+                        event.step_name,
+                        event.message,
+                        event.percent,  # None for coarse events
+                        event.timestamp.isoformat(),
+                    ),
+                )
+                conn.commit()
+                logger.debug(f"[{job_id}] Event {next_seq}: {event.step_name} - {event.phase}")
+                return True
+        except Exception as e:
+            logger.error(f"Failed to write job event for {job_id}: {e}")
+            return False
+
+    def get_job_events_since(self, job_id: str, after_seq: int = 0) -> List[Dict[str, Any]]:
+        """
+        Get job events since a sequence number (for SSE tailing).
+
+        Args:
+            job_id: Job identifier
+            after_seq: Minimum seq to fetch (exclusive; 0 = fetch all)
+
+        Returns:
+            List of event dicts ordered by seq ASC
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT seq, phase, step_name, message, percent, timestamp
+                FROM job_events
+                WHERE job_id = ? AND seq > ?
+                ORDER BY seq ASC
+            """,
+                (job_id, after_seq),
+            ).fetchall()
+
+        return [dict(row) for row in rows]

--- a/src/energizados/web/store.py
+++ b/src/energizados/web/store.py
@@ -10,7 +10,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from sqlite3 import Connection, Row, connect
+from sqlite3 import Connection, IntegrityError, Row, connect
 from typing import Any, Dict, List, Optional
 
 from energizados.web.models import JobRow, JobStatus
@@ -83,10 +83,17 @@ class JobStore:
 
                 # If percent column exists and is INTEGER, drop table for migration
                 if percent_col and len(percent_col) > 0 and percent_col[0][2] == "INTEGER":
-                    logger.info(
-                        "Migrating job_events.percent: INTEGER → REAL (dropping empty table)"
-                    )
-                    conn.execute("DROP TABLE job_events")
+                    row_count = conn.execute("SELECT COUNT(*) FROM job_events").fetchone()[0]
+                    if row_count == 0:
+                        logger.info(
+                            "Migrating job_events.percent: INTEGER → REAL (dropping empty table)"
+                        )
+                        conn.execute("DROP TABLE job_events")
+                    else:
+                        logger.warning(
+                            f"job_events.percent is INTEGER but table has {row_count} rows; "
+                            "skipping migration to avoid data loss"
+                        )
 
             # Create job_events table with corrected schema (percent as REAL nullable)
             conn.execute("""
@@ -99,6 +106,7 @@ class JobStore:
                     message TEXT NOT NULL,
                     percent REAL,
                     timestamp TEXT NOT NULL,
+                    UNIQUE(job_id, seq),
                     FOREIGN KEY (job_id) REFERENCES jobs(job_id)
                 )
                 """)
@@ -419,36 +427,37 @@ class JobStore:
             Must NOT raise — called from worker child process callback.
             Errors are logged and swallowed to avoid crashing the job.
         """
-        try:
-            with self._get_connection() as conn:
-                # Get next seq for this job (transaction ensures monotonic)
-                cursor = conn.execute(
-                    "SELECT COALESCE(MAX(seq), 0) FROM job_events WHERE job_id = ?", (job_id,)
-                )
-                next_seq = cursor.fetchone()[0] + 1
-
-                # Insert event
-                conn.execute(
-                    """
-                    INSERT INTO job_events (job_id, seq, phase, step_name, message, percent, timestamp)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                    (
-                        job_id,
-                        next_seq,
-                        event.phase,
-                        event.step_name,
-                        event.message,
-                        event.percent,  # None for coarse events
-                        event.timestamp.isoformat(),
-                    ),
-                )
-                conn.commit()
-                logger.debug(f"[{job_id}] Event {next_seq}: {event.step_name} - {event.phase}")
-                return True
-        except Exception as e:
-            logger.error(f"Failed to write job event for {job_id}: {e}")
-            return False
+        for attempt in range(20):
+            try:
+                with self._get_connection() as conn:
+                    cursor = conn.execute(
+                        "SELECT COALESCE(MAX(seq), 0) FROM job_events WHERE job_id = ?", (job_id,)
+                    )
+                    next_seq = cursor.fetchone()[0] + 1
+                    conn.execute(
+                        "INSERT INTO job_events (job_id, seq, phase, step_name, message, percent, timestamp) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            job_id,
+                            next_seq,
+                            event.phase,
+                            event.step_name,
+                            event.message,
+                            event.percent,
+                            event.timestamp.isoformat(),
+                        ),
+                    )
+                    conn.commit()
+                    logger.debug(f"[{job_id}] Event {next_seq}: {event.step_name} - {event.phase}")
+                    return True
+            except IntegrityError:
+                # concurrent writer inserted this seq first; recompute and retry
+                continue
+            except Exception as e:
+                logger.error(f"Failed to write job event for {job_id}: {e}")
+                return False
+        logger.error(f"Failed to write job event for {job_id}: seq contention after 20 attempts")
+        return False
 
     def get_job_events_since(self, job_id: str, after_seq: int = 0) -> List[Dict[str, Any]]:
         """

--- a/src/energizados/web/templates/job_detail.html
+++ b/src/energizados/web/templates/job_detail.html
@@ -58,6 +58,49 @@
     </div>
     {% endif %}
 
+    {% if not job.is_terminal() %}
+    <div class="mt-3" id="live-progress-section">
+        <h6 class="small text-uppercase text-muted mb-2">Live Progress</h6>
+        <ul id="progress-log" class="list-unstyled small text-muted"></ul>
+        <div id="progress-unsupported" class="alert alert-warning small d-none">
+            Live progress is not supported in this browser.
+        </div>
+    </div>
+    <script>
+      (function () {
+        var log = document.getElementById("progress-log");
+        if (typeof EventSource === "undefined") {
+            document.getElementById("progress-unsupported").classList.remove("d-none");
+            return;
+        }
+        var es = new EventSource("/jobs/{{ job.job_id }}/progress");
+        function appendLine(text, cls) {
+            var li = document.createElement("li");
+            li.className = cls || "";
+            li.textContent = text;
+            log.appendChild(li);
+        }
+        es.addEventListener("connected", function (e) {
+            appendLine("Connected — waiting for progress events…", "text-muted");
+        });
+        es.onmessage = function (e) {
+            var ev = JSON.parse(e.data);
+            var pct = ev.percent != null ? (" (" + ev.percent + "%)") : "";
+            appendLine(ev.step_name + " · " + ev.phase + pct + " — " + ev.message, "");
+        };
+        es.addEventListener("terminal", function (e) {
+            appendLine("Job finished.", "fw-bold");
+            es.close();
+            // Refresh the detail view so terminal state + run link render server-side.
+            if (window.htmx) { htmx.ajax("GET", "/jobs/{{ job.job_id }}",
+                            {target: ".job-card", swap: "outerHTML"}); }
+            else { location.reload(); }
+        });
+        es.onerror = function () { es.close(); };
+      })();
+    </script>
+    {% endif %}
+
     <div class="mt-3">
         <h6 class="small text-uppercase text-muted mb-2">Configuration</h6>
         <details>

--- a/src/energizados/web/templates/job_detail.html
+++ b/src/energizados/web/templates/job_detail.html
@@ -73,30 +73,33 @@
             document.getElementById("progress-unsupported").classList.remove("d-none");
             return;
         }
-        var es = new EventSource("/jobs/{{ job.job_id }}/progress");
-        function appendLine(text, cls) {
+        var eventSource = new EventSource("/jobs/{{ job.job_id }}/progress");
+        function appendProgressLine(text, cls) {
             var li = document.createElement("li");
             li.className = cls || "";
             li.textContent = text;
             log.appendChild(li);
         }
-        es.addEventListener("connected", function (e) {
-            appendLine("Connected — waiting for progress events…", "text-muted");
+        eventSource.addEventListener("connected", function (e) {
+            appendProgressLine("Connected — waiting for progress events…", "text-muted");
         });
-        es.onmessage = function (e) {
+        eventSource.onmessage = function (e) {
             var ev = JSON.parse(e.data);
             var pct = ev.percent != null ? (" (" + ev.percent + "%)") : "";
-            appendLine(ev.step_name + " · " + ev.phase + pct + " — " + ev.message, "");
+            appendProgressLine(ev.step_name + " · " + ev.phase + pct + " — " + ev.message, "");
         };
-        es.addEventListener("terminal", function (e) {
-            appendLine("Job finished.", "fw-bold");
-            es.close();
+        eventSource.addEventListener("terminal", function (e) {
+            appendProgressLine("Job finished.", "fw-bold");
+            eventSource.close();
             // Refresh the detail view so terminal state + run link render server-side.
             if (window.htmx) { htmx.ajax("GET", "/jobs/{{ job.job_id }}",
                             {target: ".job-card", swap: "outerHTML"}); }
             else { location.reload(); }
         });
-        es.onerror = function () { es.close(); };
+        eventSource.onerror = function () {
+            // EventSource reconnects automatically; do not close. The terminal event
+            // or the server-side safety cap ends the stream when appropriate.
+        };
       })();
     </script>
     {% endif %}

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -1204,11 +1204,14 @@ class TestSSEProgressEndpoint:
 
         assert response.status_code == 404
 
-    def test_sse_returns_event_stream_content_type(self, client, mock_store):
+    def test_sse_returns_event_stream_content_type(self, client, mock_store, monkeypatch):
         """GET /jobs/{job_id}/progress should return text/event-stream content-type."""
         from energizados.web.models import JobRow, JobStatus
 
-        mock_job = JobRow(
+        # Poll instantly so the running-job loop is fast in tests.
+        monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
+
+        running_job = JobRow(
             job_id="job-running-1",
             config={"train": {}},
             config_type="train",
@@ -1216,7 +1219,17 @@ class TestSSEProgressEndpoint:
             enqueued_at="2024-01-01T00:00:00Z",
             started_at="2024-01-01T00:01:00Z",
         )
-        mock_store.get_job.return_value = mock_job
+        terminal_job = JobRow(
+            job_id="job-running-1",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.SUCCESS,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+        )
+        # Route handler fetches once (running); generator polls running then terminal.
+        mock_store.get_job.side_effect = [running_job, running_job, terminal_job]
         mock_store.get_job_events_since.return_value = []
 
         response = client.get("/jobs/job-running-1/progress")
@@ -1319,11 +1332,14 @@ class TestSSEProgressEndpoint:
         # Should have terminal signal (event: terminal field)
         assert "event: terminal" in response_text
 
-    def test_sse_filters_events_by_after_seq(self, client, mock_store):
+    def test_sse_filters_events_by_after_seq(self, client, mock_store, monkeypatch):
         """GET /jobs/{job_id}/progress should filter events by after_seq parameter."""
         from energizados.web.models import JobRow, JobStatus
 
-        mock_job = JobRow(
+        # Poll instantly so the running-job loop is fast in tests.
+        monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
+
+        running_job = JobRow(
             job_id="job-running-2",
             config={"train": {}},
             config_type="train",
@@ -1331,7 +1347,16 @@ class TestSSEProgressEndpoint:
             enqueued_at="2024-01-01T00:00:00Z",
             started_at="2024-01-01T00:01:00Z",
         )
-        mock_store.get_job.return_value = mock_job
+        terminal_job = JobRow(
+            job_id="job-running-2",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.SUCCESS,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+        )
+        mock_store.get_job.side_effect = [running_job, running_job, terminal_job]
 
         # Return only one event (seq=2) when filtering after seq=1
         mock_events = [
@@ -1357,11 +1382,14 @@ class TestSSEProgressEndpoint:
         # Should NOT have seq=1 event
         assert 'data: {"seq": 1' not in response_text
 
-    def test_sse_running_job_returns_stream_and_connects(self, client, mock_store):
+    def test_sse_running_job_returns_stream_and_connects(self, client, mock_store, monkeypatch):
         """GET /jobs/{job_id}/progress for RUNNING job should return stream and emit initial event."""
         from energizados.web.models import JobRow, JobStatus
 
-        mock_job = JobRow(
+        # Poll instantly so the running-job loop is fast in tests.
+        monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
+
+        running_job = JobRow(
             job_id="job-running-3",
             config={"train": {}},
             config_type="train",
@@ -1369,7 +1397,16 @@ class TestSSEProgressEndpoint:
             enqueued_at="2024-01-01T00:00:00Z",
             started_at="2024-01-01T00:01:00Z",
         )
-        mock_store.get_job.return_value = mock_job
+        terminal_job = JobRow(
+            job_id="job-running-3",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.SUCCESS,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+        )
+        mock_store.get_job.side_effect = [running_job, running_job, terminal_job]
         mock_store.get_job_events_since.return_value = []
 
         response = client.get("/jobs/job-running-3/progress")
@@ -1378,6 +1415,8 @@ class TestSSEProgressEndpoint:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("text/event-stream")
 
-        # Should have at least some content (initial event or keep-alive)
+        # Running jobs with no events receive an immediate connected heartbeat.
         response_text = response.text
-        assert len(response_text) > 0
+        assert "event: connected" in response_text
+        # The stream closes once the job transitions to a terminal state.
+        assert "event: terminal" in response_text

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -1191,3 +1191,193 @@ class TestPostPlan:
         data = response.json()
         # Should contain error about config must be dictionary
         assert "dictionary" in str(data).lower() or "dict" in str(data).lower()
+
+
+class TestSSEProgressEndpoint:
+    """Tests for GET /jobs/{job_id}/progress SSE endpoint (Task 5)."""
+
+    def test_sse_unknown_job_returns_404(self, client, mock_store):
+        """GET /jobs/{job_id}/progress with unknown job_id should return 404."""
+        mock_store.get_job.return_value = None
+
+        response = client.get("/jobs/unknown-job-123/progress")
+
+        assert response.status_code == 404
+
+    def test_sse_returns_event_stream_content_type(self, client, mock_store):
+        """GET /jobs/{job_id}/progress should return text/event-stream content-type."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-running-1",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+        mock_store.get_job_events_since.return_value = []
+
+        response = client.get("/jobs/job-running-1/progress")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+    def test_sse_streams_events_with_correct_format(self, client, mock_store):
+        """GET /jobs/{job_id}/progress should stream events in correct SSE format."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-success-1",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.SUCCESS,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        # Mock events with proper structure
+        mock_events = [
+            {
+                "seq": 1,
+                "phase": "feature_engineering",
+                "step_name": "preprocessing",
+                "message": "Starting preprocessing",
+                "percent": 0,
+                "timestamp": "2024-01-01T00:02:00Z",
+            },
+            {
+                "seq": 2,
+                "phase": "training",
+                "step_name": "model_fit",
+                "message": "Training model",
+                "percent": 50,
+                "timestamp": "2024-01-01T00:03:00Z",
+            },
+        ]
+        mock_store.get_job_events_since.return_value = mock_events
+
+        response = client.get("/jobs/job-success-1/progress")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        response_text = response.text
+        # Check for SSE format: data: {json}\n\n
+        assert 'data: {"seq": 1' in response_text
+        assert 'data: {"seq": 2' in response_text
+        assert "\n\n" in response_text  # SSE delimiter
+
+    def test_sse_terminal_job_replays_history_then_closes(self, client, mock_store):
+        """GET /jobs/{job_id}/progress for terminal job should replay all events then close with terminal signal."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-terminal-1",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.SUCCESS,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        mock_events = [
+            {
+                "seq": 1,
+                "phase": "feature_engineering",
+                "step_name": "preprocessing",
+                "message": "Starting preprocessing",
+                "percent": 0,
+                "timestamp": "2024-01-01T00:02:00Z",
+            },
+            {
+                "seq": 2,
+                "phase": "training",
+                "step_name": "model_fit",
+                "message": "Training complete",
+                "percent": 100,
+                "timestamp": "2024-01-01T00:04:00Z",
+            },
+        ]
+        mock_store.get_job_events_since.return_value = mock_events
+
+        response = client.get("/jobs/job-terminal-1/progress")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        response_text = response.text
+        # All events should be present
+        assert 'data: {"seq": 1' in response_text
+        assert 'data: {"seq": 2' in response_text
+
+        # Should have terminal signal (event: terminal field)
+        assert "event: terminal" in response_text
+
+    def test_sse_filters_events_by_after_seq(self, client, mock_store):
+        """GET /jobs/{job_id}/progress should filter events by after_seq parameter."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-running-2",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        # Return only one event (seq=2) when filtering after seq=1
+        mock_events = [
+            {
+                "seq": 2,
+                "phase": "training",
+                "step_name": "model_fit",
+                "message": "Training model",
+                "percent": 50,
+                "timestamp": "2024-01-01T00:03:00Z",
+            }
+        ]
+        mock_store.get_job_events_since.return_value = mock_events
+
+        response = client.get("/jobs/job-running-2/progress")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        response_text = response.text
+        # Should have the filtered event
+        assert 'data: {"seq": 2' in response_text
+        # Should NOT have seq=1 event
+        assert 'data: {"seq": 1' not in response_text
+
+    def test_sse_running_job_returns_stream_and_connects(self, client, mock_store):
+        """GET /jobs/{job_id}/progress for RUNNING job should return stream and emit initial event."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-running-3",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+        mock_store.get_job_events_since.return_value = []
+
+        response = client.get("/jobs/job-running-3/progress")
+
+        # Should return streaming response
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        # Should have at least some content (initial event or keep-alive)
+        response_text = response.text
+        assert len(response_text) > 0

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -79,6 +79,22 @@ def fake_run_dir(tmp_path):
     return run_dir
 
 
+def _make_job(job_id, status, **overrides):
+    """Helper to create JobRow instances with common defaults."""
+    from energizados.web.models import JobRow
+
+    base = dict(
+        job_id=job_id,
+        config={"train": {}},
+        config_type="train",
+        status=status,
+        enqueued_at="2024-01-01T00:00:00Z",
+        started_at="2024-01-01T00:01:00Z",
+    )
+    base.update(overrides)
+    return JobRow(**base)
+
+
 class TestRootRoute:
     """Tests for GET / route (task 5.10)."""
 
@@ -1206,27 +1222,14 @@ class TestSSEProgressEndpoint:
 
     def test_sse_returns_event_stream_content_type(self, client, mock_store, monkeypatch):
         """GET /jobs/{job_id}/progress should return text/event-stream content-type."""
-        from energizados.web.models import JobRow, JobStatus
+        from energizados.web.models import JobStatus
 
         # Poll instantly so the running-job loop is fast in tests.
         monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
 
-        running_job = JobRow(
-            job_id="job-running-1",
-            config={"train": {}},
-            config_type="train",
-            status=JobStatus.RUNNING,
-            enqueued_at="2024-01-01T00:00:00Z",
-            started_at="2024-01-01T00:01:00Z",
-        )
-        terminal_job = JobRow(
-            job_id="job-running-1",
-            config={"train": {}},
-            config_type="train",
-            status=JobStatus.SUCCESS,
-            enqueued_at="2024-01-01T00:00:00Z",
-            started_at="2024-01-01T00:01:00Z",
-            finished_at="2024-01-01T00:05:00Z",
+        running_job = _make_job("job-running-1", JobStatus.RUNNING)
+        terminal_job = _make_job(
+            "job-running-1", JobStatus.SUCCESS, finished_at="2024-01-01T00:05:00Z"
         )
         # Route handler fetches once (running); generator polls running then terminal.
         mock_store.get_job.side_effect = [running_job, running_job, terminal_job]
@@ -1334,27 +1337,14 @@ class TestSSEProgressEndpoint:
 
     def test_sse_filters_events_by_after_seq(self, client, mock_store, monkeypatch):
         """GET /jobs/{job_id}/progress should filter events by after_seq parameter."""
-        from energizados.web.models import JobRow, JobStatus
+        from energizados.web.models import JobStatus
 
         # Poll instantly so the running-job loop is fast in tests.
         monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
 
-        running_job = JobRow(
-            job_id="job-running-2",
-            config={"train": {}},
-            config_type="train",
-            status=JobStatus.RUNNING,
-            enqueued_at="2024-01-01T00:00:00Z",
-            started_at="2024-01-01T00:01:00Z",
-        )
-        terminal_job = JobRow(
-            job_id="job-running-2",
-            config={"train": {}},
-            config_type="train",
-            status=JobStatus.SUCCESS,
-            enqueued_at="2024-01-01T00:00:00Z",
-            started_at="2024-01-01T00:01:00Z",
-            finished_at="2024-01-01T00:05:00Z",
+        running_job = _make_job("job-running-2", JobStatus.RUNNING)
+        terminal_job = _make_job(
+            "job-running-2", JobStatus.SUCCESS, finished_at="2024-01-01T00:05:00Z"
         )
         mock_store.get_job.side_effect = [running_job, running_job, terminal_job]
 
@@ -1384,27 +1374,14 @@ class TestSSEProgressEndpoint:
 
     def test_sse_running_job_returns_stream_and_connects(self, client, mock_store, monkeypatch):
         """GET /jobs/{job_id}/progress for RUNNING job should return stream and emit initial event."""
-        from energizados.web.models import JobRow, JobStatus
+        from energizados.web.models import JobStatus
 
         # Poll instantly so the running-job loop is fast in tests.
         monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
 
-        running_job = JobRow(
-            job_id="job-running-3",
-            config={"train": {}},
-            config_type="train",
-            status=JobStatus.RUNNING,
-            enqueued_at="2024-01-01T00:00:00Z",
-            started_at="2024-01-01T00:01:00Z",
-        )
-        terminal_job = JobRow(
-            job_id="job-running-3",
-            config={"train": {}},
-            config_type="train",
-            status=JobStatus.SUCCESS,
-            enqueued_at="2024-01-01T00:00:00Z",
-            started_at="2024-01-01T00:01:00Z",
-            finished_at="2024-01-01T00:05:00Z",
+        running_job = _make_job("job-running-3", JobStatus.RUNNING)
+        terminal_job = _make_job(
+            "job-running-3", JobStatus.SUCCESS, finished_at="2024-01-01T00:05:00Z"
         )
         mock_store.get_job.side_effect = [running_job, running_job, terminal_job]
         mock_store.get_job_events_since.return_value = []
@@ -1420,6 +1397,30 @@ class TestSSEProgressEndpoint:
         assert "event: connected" in response_text
         # The stream closes once the job transitions to a terminal state.
         assert "event: terminal" in response_text
+
+    def test_sse_safety_cap_closes_without_terminal(self, client, mock_store, monkeypatch):
+        """SSE safety cap closes silently without emitting terminal event."""
+        from energizados.web.models import JobStatus
+
+        # Configure instant polling and small cap for fast test
+        monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
+        monkeypatch.setattr("energizados.web.app.SSE_MAX_POLL_ITERATIONS", 3)
+
+        running_job = _make_job("job-running-forever", JobStatus.RUNNING)
+        # get_job is called once in route + once per iteration (3 iterations = 4 calls)
+        mock_store.get_job.side_effect = lambda *a, **kw: running_job
+        mock_store.get_job_events_since.return_value = []
+
+        response = client.get("/jobs/job-running-forever/progress")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        response_text = response.text
+        # Should contain connected heartbeat
+        assert "event: connected" in response_text
+        # Should NOT contain terminal event (safety cap closes silently)
+        assert "event: terminal" not in response_text
 
 
 class TestJobDetailProgressUI:

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -1420,3 +1420,126 @@ class TestSSEProgressEndpoint:
         assert "event: connected" in response_text
         # The stream closes once the job transitions to a terminal state.
         assert "event: terminal" in response_text
+
+
+class TestJobDetailProgressUI:
+    """Tests for EventSource live-progress integration in job detail template (Task 6)."""
+
+    def test_job_detail_includes_eventsource_for_running_job(self, client, mock_store):
+        """GET /jobs/{id} for RUNNING job should include EventSource initialization."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-xyz",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        response = client.get("/jobs/job-xyz")
+
+        assert response.status_code == 200
+        content = response.text
+        # Should contain EventSource initialization
+        assert "EventSource" in content
+        # Should reference the progress URL
+        assert "/jobs/job-xyz/progress" in content
+        mock_store.get_job.assert_called_once_with("job-xyz")
+
+    def test_job_detail_includes_progress_container_for_running_job(self, client, mock_store):
+        """GET /jobs/{id} for RUNNING job should include progress log container."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-abc",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        response = client.get("/jobs/job-abc")
+
+        assert response.status_code == 200
+        content = response.text
+        # Should contain a progress container element (e.g., id="progress-log" or class="progress-log")
+        assert "progress-log" in content
+        mock_store.get_job.assert_called_once_with("job-abc")
+
+    def test_job_detail_no_eventsource_for_terminal_job(self, client, mock_store):
+        """GET /jobs/{id} for SUCCESS job should NOT include EventSource or progress URL."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-terminal",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.SUCCESS,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        response = client.get("/jobs/job-terminal")
+
+        assert response.status_code == 200
+        content = response.text
+        # Should NOT contain EventSource
+        assert "EventSource" not in content
+        # Should NOT contain progress URL
+        assert "/jobs/job-terminal/progress" not in content
+        mock_store.get_job.assert_called_once_with("job-terminal")
+
+    def test_eventsource_terminal_handler_triggers_htmx_refresh(self, client, mock_store):
+        """GET /jobs/{id} for RUNNING job should include terminal event handler with HTMX refresh."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-running-refresh",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        response = client.get("/jobs/job-running-refresh")
+
+        assert response.status_code == 200
+        content = response.text
+        # Should contain handler for 'terminal' event
+        assert "terminal" in content
+        # Should trigger HTMX refresh or page reload
+        assert "htmx.ajax" in content or "location.reload" in content
+        mock_store.get_job.assert_called_once_with("job-running-refresh")
+
+    def test_eventsource_has_unsupported_fallback(self, client, mock_store):
+        """GET /jobs/{id} for RUNNING job should include fallback for unsupported EventSource."""
+        from energizados.web.models import JobRow, JobStatus
+
+        mock_job = JobRow(
+            job_id="job-unsupported",
+            config={"train": {}},
+            config_type="train",
+            status=JobStatus.RUNNING,
+            enqueued_at="2024-01-01T00:00:00Z",
+            started_at="2024-01-01T00:01:00Z",
+        )
+        mock_store.get_job.return_value = mock_job
+
+        response = client.get("/jobs/job-unsupported")
+
+        assert response.status_code == 200
+        content = response.text
+        # Should check for EventSource support
+        assert "typeof EventSource" in content
+        # Should show user-visible fallback message
+        assert "unsupported" in content.lower() or "not supported" in content.lower()
+        mock_store.get_job.assert_called_once_with("job-unsupported")

--- a/tests/web/test_integration.py
+++ b/tests/web/test_integration.py
@@ -5,9 +5,16 @@ Following strict TDD: tests written first (RED), then implementation (GREEN).
 Tests worker startup, shutdown, and basic job processing.
 """
 
+from datetime import datetime, timezone
+from threading import Thread
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from energizados.api.progress import ProgressEvent
+from energizados.web.models import JobStatus
 from energizados.web.store import JobStore
+from energizados.web.store import JobStore as _RealJobStore
 from energizados.web.worker import main, parse_args
 
 
@@ -183,3 +190,119 @@ class TestWorkerIntegration:
         # Loop survived the exception and exited cleanly
         assert call_count["n"] >= 1
         assert runner.store is store
+
+
+class TestSseIntegration:
+    """Integration tests for SSE live progress with real JobStore."""
+
+    @pytest.fixture
+    def real_store_app(self, tmp_path, monkeypatch):
+        """FastAPI TestClient wired to a REAL JobStore on a tmp DB (no mocks)."""
+        db_path = str(tmp_path / "integration.db")
+        # Make app.JobStore() return a real store pointing at the tmp DB.
+        monkeypatch.setattr(
+            "energizados.web.app.JobStore",
+            lambda *a, **kw: _RealJobStore(db_path=db_path),
+        )
+        # IMPORTANT: poll instantly so the running-job loop does not sleep 1s per iteration.
+        monkeypatch.setattr("energizados.web.app.SSE_POLL_INTERVAL_SECONDS", 0.0)
+        from fastapi.testclient import TestClient
+
+        from energizados.web.app import app
+
+        return TestClient(app), _RealJobStore(db_path=db_path)
+
+    def test_sse_streams_real_events_then_closes_on_terminal(self, real_store_app):
+        """End-to-end: real store writes events, SSE streams them, then closes when terminal."""
+        client, store = real_store_app
+
+        # Create job and events
+        job_id = store.create_job({"train": {}}, "train")
+        store.update_status(job_id, JobStatus.RUNNING)
+        store.append_job_event(
+            job_id,
+            ProgressEvent(
+                run_id="unknown",
+                step_name="etl",
+                phase="start",
+                message="Starting ETL",
+                percent=0.0,
+                timestamp=datetime.now(timezone.utc),
+            ),
+        )
+        store.append_job_event(
+            job_id,
+            ProgressEvent(
+                run_id="unknown",
+                step_name="etl",
+                phase="complete",
+                message="ETL done",
+                percent=100.0,
+                timestamp=datetime.now(timezone.utc),
+            ),
+        )
+
+        # Mark terminal BEFORE requesting SSE stream for deterministic close
+        store.update_status(job_id, JobStatus.SUCCESS)
+
+        response = client.get(f"/jobs/{job_id}/progress")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        text = response.text
+        assert 'data: {"seq": 1' in text
+        assert 'data: {"seq": 2' in text
+        assert "event: terminal" in text
+        assert '"status": "success"' in text
+
+
+class TestJobStoreConcurrency:
+    """Integration tests for JobStore thread-safety under concurrent load."""
+
+    def test_concurrent_read_write_isolation(self, tmp_path):
+        """Thread-safety of JobStore under concurrent worker writes + web reads."""
+        db_path = str(tmp_path / "concurrent.db")
+        store = _RealJobStore(db_path=db_path)
+        write_errors = []
+        read_errors = []
+
+        job_id = store.create_job({"train": {}}, "train")
+        store.update_status(job_id, JobStatus.RUNNING)
+
+        def writer():
+            for i in range(50):
+                try:
+                    store.append_job_event(
+                        job_id,
+                        ProgressEvent(
+                            run_id="unknown",
+                            step_name="step",
+                            phase="progress",
+                            message=f"Event {i}",
+                            percent=float(i),
+                            timestamp=datetime.now(timezone.utc),
+                        ),
+                    )
+                except Exception as e:
+                    write_errors.append(e)
+
+        def reader():
+            for _ in range(50):
+                try:
+                    store.get_job_events_since(job_id, after_seq=0)
+                except Exception as e:
+                    read_errors.append(e)
+
+        w = Thread(target=writer)
+        r = Thread(target=reader)
+        w.start()
+        r.start()
+        w.join()
+        r.join()
+
+        assert write_errors == []
+        assert read_errors == []
+        events = store.get_job_events_since(job_id, after_seq=0)
+        assert len(events) == 50
+        assert [e["seq"] for e in events] == list(range(1, 51))

--- a/tests/web/test_runner.py
+++ b/tests/web/test_runner.py
@@ -28,6 +28,66 @@ class TestJobRunnerInit:
         assert runner._current_job_id is None
 
 
+class TestJobRunnerProgressCallback:
+    """Test progress_callback integration with JobStore."""
+
+    def test_progress_callback_writes_to_job_events_direct(self, tmp_path):
+        """Test callback function directly writes events to JobStore."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        # Simulate callback behavior
+        event = ProgressEvent(
+            run_id="unknown",
+            step_name="etl",
+            phase="start",
+            message="Starting ETL",
+            percent=0.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        # Call append_job_event directly (what callback does)
+        success = store.append_job_event(job_id, event)
+
+        # Verify event was written
+        assert success is True
+        events = store.get_job_events_since(job_id, after_seq=0)
+        assert len(events) == 1
+        assert events[0]["step_name"] == "etl"
+        assert events[0]["phase"] == "start"
+
+    def test_progress_callback_isolation_on_db_failure(self, tmp_path):
+        """Callback failure doesn't raise exception (isolated error handling)."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        event = ProgressEvent(
+            run_id="unknown",
+            step_name="etl",
+            phase="start",
+            message="Starting ETL",
+            percent=0.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        # Mock _get_connection to simulate DB failure
+        from unittest.mock import patch
+
+        with patch.object(store, "_get_connection", side_effect=Exception("DB locked")):
+            # Should return False, not raise
+            result = store.append_job_event(job_id, event)
+
+        assert result is False  # Returns False, doesn't crash
+
+
 class TestJobRunnerPoll:
     """Test JobRunner poll loop."""
 

--- a/tests/web/test_store.py
+++ b/tests/web/test_store.py
@@ -212,6 +212,56 @@ class TestJobStoreAppendEvent:
 
         assert result is False  # Returns False, doesn't raise
 
+    def test_append_job_event_concurrent_writers_unique_seq(self, tmp_path):
+        """Concurrent writers to same job generate unique monotonic seqs."""
+        import threading
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        num_threads = 10
+        events_per_thread = 10
+        errors = []
+
+        def append_events(thread_id):
+            """Append events from one thread (simulates concurrent worker callbacks)."""
+            for i in range(events_per_thread):
+                event = ProgressEvent(
+                    run_id="unknown",
+                    step_name=f"thread{thread_id}_step{i}",
+                    phase="running",
+                    message=f"Thread {thread_id} event {i}",
+                    percent=float(i * 10),
+                    timestamp=datetime.now(timezone.utc),
+                )
+                if not store.append_job_event(job_id, event):
+                    errors.append(f"Thread {thread_id} failed to write event {i}")
+
+        threads = []
+        for t in range(num_threads):
+            thread = threading.Thread(target=append_events, args=(t,))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # No write failures
+        assert not errors, f"Write errors occurred: {errors}"
+
+        # All events persisted with unique seqs
+        events = store.get_job_events_since(job_id, after_seq=0)
+        expected_count = num_threads * events_per_thread
+        assert len(events) == expected_count, f"Expected {expected_count} events, got {len(events)}"
+
+        # Extract seqs and verify they are exactly 1..100 (no gaps, no duplicates)
+        seqs = {event["seq"] for event in events}
+        expected_seqs = set(range(1, expected_count + 1))
+        assert seqs == expected_seqs, f"Seqs are {sorted(seqs)}, expected {sorted(expected_seqs)}"
+
 
 class TestJobStoreGetEventsSince:
     """Test get_job_events_since query and ordering."""

--- a/tests/web/test_store.py
+++ b/tests/web/test_store.py
@@ -47,6 +47,265 @@ class TestJobStoreSchema:
         assert "job_events" in table_names
 
 
+class TestJobStoreSchemaMigration:
+    """Test job_events.percent column migration INTEGER → REAL."""
+
+    def test_percent_column_is_real_nullable(self, tmp_path):
+        """Schema migration creates percent as REAL nullable."""
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+
+        with store._get_connection() as conn:
+            columns = conn.execute("PRAGMA table_info(job_events)").fetchall()
+            percent_col = [c for c in columns if c["name"] == "percent"]
+
+        assert len(percent_col) == 1
+        assert percent_col[0]["type"] == "REAL"
+        assert percent_col[0]["notnull"] == 0  # Nullable
+
+    def test_migration_idempotent(self, tmp_path):
+        """Migration can run multiple times safely."""
+        db_path = tmp_path / "test.db"
+
+        # Create first store (triggers migration)
+        JobStore(db_path=str(db_path))
+
+        # Create second store (should not fail)
+        store = JobStore(db_path=str(db_path))
+
+        # Verify schema still valid
+        with store._get_connection() as conn:
+            columns = conn.execute("PRAGMA table_info(job_events)").fetchall()
+            percent_col = [c for c in columns if c["name"] == "percent"]
+
+        assert len(percent_col) == 1
+        assert percent_col[0]["type"] == "REAL"
+
+
+class TestJobStoreAppendEvent:
+    """Test append_job_event persistence with monotonic seq."""
+
+    def test_append_event_assigns_monotonic_seq(self, tmp_path):
+        """Seq increments monotonically per job (1, 2, 3...)."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        event1 = ProgressEvent(
+            run_id="unknown",
+            step_name="etl",
+            phase="start",
+            message="Starting ETL",
+            percent=0.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        event2 = ProgressEvent(
+            run_id="unknown",
+            step_name="etl",
+            phase="complete",
+            message="ETL complete",
+            percent=100.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        success1 = store.append_job_event(job_id, event1)
+        success2 = store.append_job_event(job_id, event2)
+
+        assert success1 is True
+        assert success2 is True
+
+        events = store.get_job_events_since(job_id, after_seq=0)
+        assert events[0]["seq"] == 1
+        assert events[1]["seq"] == 2
+
+    def test_append_event_maps_progressevent_fields(self, tmp_path):
+        """All ProgressEvent fields map to job_events columns."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        event = ProgressEvent(
+            run_id="run-123",
+            step_name="training",
+            phase="start",
+            message="Starting training",
+            percent=50.5,  # Float value
+            timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+        store.append_job_event(job_id, event)
+
+        rows = store.get_job_events_since(job_id, after_seq=0)
+        assert len(rows) == 1
+        assert rows[0]["step_name"] == "training"
+        assert rows[0]["phase"] == "start"
+        assert rows[0]["message"] == "Starting training"
+        assert rows[0]["percent"] == 50.5
+        assert rows[0]["timestamp"] == "2024-01-01T12:00:00+00:00"
+
+    def test_append_event_isolated_per_job(self, tmp_path):
+        """Seq monotonicity isolated per job (not global)."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job1_id = store.create_job({"train": {}}, "train")
+        job2_id = store.create_job({"etl": {}}, "etl")
+
+        event1 = ProgressEvent(
+            run_id="unknown",
+            step_name="step1",
+            phase="start",
+            message="Job1 step1",
+            percent=0.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+        event2 = ProgressEvent(
+            run_id="unknown",
+            step_name="step2",
+            phase="start",
+            message="Job2 step2",
+            percent=0.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        store.append_job_event(job1_id, event1)
+        store.append_job_event(job2_id, event2)
+
+        # Each job has seq=1 (not global seq=1, seq=2)
+        job1_events = store.get_job_events_since(job1_id, after_seq=0)
+        job2_events = store.get_job_events_since(job2_id, after_seq=0)
+
+        assert job1_events[0]["seq"] == 1
+        assert job2_events[0]["seq"] == 1
+
+    def test_append_event_handles_write_failure(self, tmp_path):
+        """Write failure returns False, logs error, never raises."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        from energizados.api.progress import ProgressEvent
+
+        # Mock store with broken connection
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        event = ProgressEvent(
+            run_id="unknown",
+            step_name="test",
+            phase="start",
+            message="Test event",
+            percent=0.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        # Mock _get_connection to raise exception
+        with patch.object(store, "_get_connection", side_effect=Exception("DB error")):
+            result = store.append_job_event(job_id, event)
+
+        assert result is False  # Returns False, doesn't raise
+
+
+class TestJobStoreGetEventsSince:
+    """Test get_job_events_since query and ordering."""
+
+    def test_get_events_filters_by_seq(self, tmp_path):
+        """Returns only events with seq > after_seq."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        # Append 5 events
+        for i in range(5):
+            event = ProgressEvent(
+                run_id="unknown",
+                step_name=f"step{i}",
+                phase="start",
+                message=f"Step {i}",
+                percent=0.0,
+                timestamp=datetime.now(timezone.utc),
+            )
+            store.append_job_event(job_id, event)
+
+        # Fetch after seq=3
+        events = store.get_job_events_since(job_id, after_seq=3)
+
+        assert len(events) == 2  # seq 4 and 5
+        assert events[0]["seq"] == 4
+        assert events[1]["seq"] == 5
+
+    def test_get_events_ordered_by_seq_asc(self, tmp_path):
+        """Events returned in strict seq ASC order."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        # Append events
+        for step in ["training", "etl", "eda"]:  # Intentionally out of order
+            event = ProgressEvent(
+                run_id="unknown",
+                step_name=step,
+                phase="start",
+                message=f"Running {step}",
+                percent=0.0,
+                timestamp=datetime.now(timezone.utc),
+            )
+            store.append_job_event(job_id, event)
+
+        events = store.get_job_events_since(job_id, after_seq=0)
+
+        # Should be in seq order (insertion order here)
+        assert events[0]["step_name"] == "training"
+        assert events[1]["step_name"] == "etl"
+        assert events[2]["step_name"] == "eda"
+
+    def test_get_events_empty_for_new_job(self, tmp_path):
+        """Returns empty list for job with no events."""
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        events = store.get_job_events_since(job_id, after_seq=0)
+
+        assert events == []
+
+    def test_get_events_after_seq_zero_returns_all(self, tmp_path):
+        """after_seq=0 returns all events for the job."""
+        from datetime import datetime, timezone
+
+        from energizados.api.progress import ProgressEvent
+
+        store = JobStore(db_path=str(tmp_path / "test.db"))
+        job_id = store.create_job({"train": {}}, "train")
+
+        event = ProgressEvent(
+            run_id="unknown",
+            step_name="test",
+            phase="complete",
+            message="Done",
+            percent=100.0,
+            timestamp=datetime.now(timezone.utc),
+        )
+        store.append_job_event(job_id, event)
+
+        events = store.get_job_events_since(job_id, after_seq=0)
+
+        assert len(events) == 1
+        assert events[0]["seq"] == 1
+
+
 class TestJobStoreCRUD:
     """Test JobStore CRUD operations."""
 


### PR DESCRIPTION
## Summary

Phase 5 — the final phase of the web-console MVP. Adds **Server-Sent Events (SSE) live progress** so operators can watch a running job's pipeline progress in real time, replacing the 2-second HTMX polling uncertainty ("is it stuck?").

Pipeline `ProgressEvent`s emitted by the worker are now persisted to a new `job_events` SQLite table and streamed to the job-detail UI over an SSE connection.

## What changed

- **`store.py`** — new `job_events` table (per-job monotonic `seq`, `percent` as REAL), `append_job_event()` (atomic seq allocation via `UNIQUE(job_id, seq)` + retry), `get_job_events_since(after_seq=)`, and an idempotent schema migration (`percent` INTEGER → REAL) that guards against data loss.
- **`runner.py`** — worker `progress_callback` writes `ProgressEvent`s to `job_events`; callback failures are logged and never abort the pipeline.
- **`app.py`** — `GET /jobs/{job_id}/progress` SSE endpoint. Streams events with `id:` fields, supports resume via the `Last-Event-ID` header, emits a `connected` heartbeat for running jobs, a `terminal` event on real job completion, and closes silently on the 1-hour safety backstop (client reconnects natively).
- **`job_detail.html`** — EventSource block (only for non-terminal jobs) that appends progress lines, relies on native reconnect (no permanent kill on transient errors), and HTMX-refreshes the detail view on terminal.
- **Tests** — `test_store.py`, `test_runner.py`, `test_app.py` (`TestSSEProgressEndpoint`, `TestJobDetailProgressUI`), and a new `test_integration.py` (genuine store→SSE end-to-end with a real SQLite DB + a thread-safety test). **215 web tests pass.**

## Review

Full 4R review (risk / resilience / readability / reliability) ran against the diff. Findings addressed in this PR:
- **Reliability**: `append_job_event` seq race → atomic `UNIQUE` + retry, with a concurrent-writer test that proves uniqueness.
- **Resilience**: client `onerror` no longer kills the stream permanently (native reconnect); the safety backstop no longer masquerades as `terminal`/“Job finished”; resume via `Last-Event-ID` prevents duplicate replay on reconnect; migration no longer drops a non-empty table.
- **Readability**: SSE event-name constants extracted; test fixture duplication reduced via a `_make_job` helper; client var naming polished.

## Known MVP limitations (intentional, internal-team scope)

- **No authz** on `/jobs/{job_id}/progress` (or any web route) — the console is for a small internal team.
- **No SSE connection limit / rate limiting** — acceptable at expected internal concurrency; each stream is lightweight (async + per-op SQLite connections under WAL).

## Out of scope (deferred)

- App-wide pattern of synchronous file I/O inside async routes (pre-existing, cross-cutting).
- Browser-harness UI tests for the EventSource flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)